### PR TITLE
Fix a bug where no default config name set by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const envSchema = require('env-schema')
 function loadAndValidateEnvironment (fastify, opts, done) {
   try {
     const config = envSchema(opts)
-    const confKey = opts.confKey
+    const confKey = opts.confKey || 'config'
     fastify.decorate(confKey, config)
     done()
   } catch (err) {

--- a/test/fastify-env.test.js
+++ b/test/fastify-env.test.js
@@ -6,7 +6,6 @@ const fastifyEnv = require('../index')
 
 function makeTest (t, options, isOk, confExpected, errorMessage) {
   t.plan(isOk ? 2 : 1)
-  options = Object.assign({ confKey: 'config' }, options)
 
   const fastify = Fastify()
   fastify.register(fastifyEnv, options)
@@ -258,4 +257,26 @@ tests.forEach(function (testConf) {
 
     makeTest(t, options, testConf.isOk, testConf.confExpected, testConf.errorMessage)
   })
+})
+
+t.test('should use custom config key name', async t => {
+  const schema = {
+    type: 'object',
+    required: [ 'PORT' ],
+    properties: {
+      PORT: {
+        type: 'integer',
+        default: 6666
+      }
+    }
+  }
+
+  const fastify = Fastify()
+  await fastify.register(fastifyEnv, {
+    schema: schema,
+    confKey: 'customConfigKeyName'
+  })
+    .ready(() => {
+      t.strictSame(fastify.customConfigKeyName, { PORT: 6666 })
+    })
 })

--- a/test/fastify-env.test.js
+++ b/test/fastify-env.test.js
@@ -259,7 +259,8 @@ tests.forEach(function (testConf) {
   })
 })
 
-t.test('should use custom config key name', async t => {
+t.test('should use custom config key name', t => {
+  t.plan(1)
   const schema = {
     type: 'object',
     required: [ 'PORT' ],
@@ -272,7 +273,7 @@ t.test('should use custom config key name', async t => {
   }
 
   const fastify = Fastify()
-  await fastify.register(fastifyEnv, {
+  fastify.register(fastifyEnv, {
     schema: schema,
     confKey: 'customConfigKeyName'
   })


### PR DESCRIPTION
After updating the package to 1.0.0 the default name for the config key is not assigns anymore.
A test included.