### PR TITLE
Updated the README Typescript example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,15 @@ const options = {
 In order to have typing for the fastify instance, you should follow the example below:
 
 ```typescript
-declare module 'fastify' {
+import fastify from 'fastify'; // This line will import the original typings
+
+// Do not add declare here you will loose the other typings
+module 'fastify' {
+  // Modify you interfaces here
   interface FastifyInstance {
     config: { // this should be same as the confKey in options
       // specify your typing here
+      PORT: string;
     };
   }
 }


### PR DESCRIPTION
Update to the README's Typescript example. The current one didn't work for me the typing was not there and I lost all the default typing.

The new version augment the provided typing and was tested in Webstorm.

#### Checklist

- [NA] run `npm run test` and `npm run benchmark`
- [NA] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
