### PR TITLE
fix(readme): fix typescript types documentation to extend the FastifyInstance ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,14 @@ const options = {
 In order to have typing for the fastify instance, you should follow the example below:
 
 ```typescript
+import { FastifyInstance } from 'fastify';
+
 declare module 'fastify' {
-  interface FastifyInstance {
-    config: { // this should be same as the confKey in options
-      // specify your typing here
-    };
-  }
+    interface FastifyInstance extends FastifyInstance {
+        config: { // this should be same as the confKey in options
+            // specify your typing here
+        };
+    }
 }
 ```
 


### PR DESCRIPTION
This PR fixes the typescript types documentation. In the original snippet, the FastifyInstance typings are replaced by the ones defined by the snippet.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
