### PR TITLE
Add Post-Build Step for Handling .env Files in TypeScript Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # @fastify/env
 
 ![CI](https://github.com/fastify/fastify-env/workflows/CI/badge.svg)
@@ -8,15 +9,15 @@ Fastify plugin to check environment variables
 
 ## Install
 
-```
+```bash
 npm i @fastify/env
 ```
 
 ## Usage
 
 ```js
-const fastify = require('fastify')()
-const fastifyEnv = require('@fastify/env')
+const fastify = require('fastify')();
+const fastifyEnv = require('@fastify/env');
 
 const schema = {
   type: 'object',
@@ -27,41 +28,42 @@ const schema = {
       default: 3000
     }
   }
-}
+};
 
 const options = {
   confKey: 'config', // optional, default: 'config'
   schema: schema,
   data: data // optional, default: process.env
-}
+};
 
 fastify
   .register(fastifyEnv, options)
   .ready((err) => {
-    if (err) console.error(err)
+    if (err) console.error(err);
 
-    console.log(fastify.config) // or fastify[options.confKey]
-    console.log(fastify.getEnvs())
+    console.log(fastify.config); // or fastify[options.confKey]
+    console.log(fastify.getEnvs());
     // output: { PORT: 3000 }
-  })
+  });
 ```
 
-You can also use the function `getEnvs()` of the Request from within a handler function: 
+You can also use the function `getEnvs()` of the Request from within a handler function:
+
 ```js
 fastify.get('/', (request, reply) => {
-    console.log(request.getEnvs())
+    console.log(request.getEnvs());
     // output: { PORT: 3000 }
-})
+});
 ```
+
 Note that the `getEnvs` decorators will not be added if they already exist.
 
-This module is a wrapper around [env-schema](https://www.npmjs.com/package/env-schema).
-To read an `.env` file you must set `dotenv` in the options:
+This module is a wrapper around [env-schema](https://www.npmjs.com/package/env-schema). To read an `.env` file, you must set `dotenv` in the options:
 
 ```js
 const options = {
   dotenv: true // will read .env in root folder
-}
+};
 
 // or, pass config options available on dotenv module
 const options = {
@@ -69,66 +71,89 @@ const options = {
     path: `${__dirname}/.env`,
     debug: true
   }
-}
-
+};
 ```
-### Using @fastify/env to configure other plugins
-The `@fastify/env` plugin loads asynchronously. If you wish to use its values in a different plugin before the boot sequence, you need to make sure that:
+
+### Using @fastify/env to Configure Other Plugins
+
+The `@fastify/env` plugin loads asynchronously. To use its values in a different plugin before the boot sequence, you need to make sure that:
 1. `@fastify/env` is registered first.
-2. Await the plugin registration or await after()
+2. Await the plugin registration or use `await fastify.ready()`.
 
 ```js
-await fastify.register(fastifyEnv)
+await fastify.register(fastifyEnv);
 // fastify.config can be used in here
 ```
 
 OR
+
 ```js
-fastify.register(fastifyEnv)
-await fastify
+fastify.register(fastifyEnv);
+await fastify.ready();
 // fastify.config can be used in here
 ```
-**NB** Support for additional properties in the schema is disabled for this plugin, with the `additionalProperties` flag set to `false` internally.
 
-### Typescript
-In order to have typing for the fastify instance, you should either:
+**NB:** Support for additional properties in the schema is disabled for this plugin, with the `additionalProperties` flag set to `false` internally.
 
-- use the `declaration merging` technique to enhance the `FastifyInstance` type with the property and its keys you have defined in the options:
+### TypeScript
+
+To properly type the Fastify instance with TypeScript, follow one of these approaches:
+
+#### 1. Declaration Merging
+
+Use declaration merging to enhance the `FastifyInstance` type with the properties and keys defined in your options:
 
 ```typescript
 declare module 'fastify' {
   interface FastifyInstance {
-    config: { // this should be same as the confKey in options
+    config: { // this should be the same as the confKey in options
       // specify your typing here
-      FOO: string
+      FOO: string;
     };
   }
 }
 
-const fastify = Fastify()
-fastify.register(fastifyEnv)
+const fastify = Fastify();
+fastify.register(fastifyEnv);
 
-fastify.config.FOO // will be a string
-fastify.config.BAR // error: Property BAR does not exist on type { FOO: string }
+fastify.config.FOO; // will be a string
+fastify.config.BAR; // error: Property BAR does not exist on type { FOO: string }
 ```
 
-- use the generic function `getEnvs()` to get the already typed object:
+#### 2. Using `getEnvs()` Generic Function
+
+Use the generic function `getEnvs()` to obtain a typed object:
 
 ```typescript
 type Envs = {
-  FOO: string
-}
+  FOO: string;
+};
 
-const fastify = Fastify()
-await fastify.register(fastifyEnv)
+const fastify = Fastify();
+await fastify.register(fastifyEnv);
 
-const envs = fastify.getEnvs<Envs>() // envs will be of type Envs
+const envs = fastify.getEnvs<Envs>(); // envs will be of type Envs
 
-envs.FOO // will be a string
-envs.BAR // error: Property BAR does not exist on type Envs
+envs.FOO; // will be a string
+envs.BAR; // error: Property BAR does not exist on type Envs
 ```
-If this is the case it is suggested to use [json-schema-to-ts ](https://github.com/ThomasAribart/json-schema-to-ts) to have the type always synchronized with the actual schema. 
+
+To keep types synchronized with the schema, consider using [json-schema-to-ts](https://github.com/ThomasAribart/json-schema-to-ts).
+
+### Handling `.env` Files in TypeScript Projects
+
+To ensure that the `.env` file is copied to the `dist/` directory after TypeScript compilation, you can add a post-build step to your `package.json` scripts:
+
+```json
+"scripts": {
+  "build": "tsc && cp .env dist/",
+  "start": "node dist/app.js"
+}
+```
+
+This script will compile your TypeScript code and copy the `.env` file to the `dist/` directory.
 
 ## Acknowledgements
 
 Kindly sponsored by [Mia Platform](https://www.mia-platform.eu/)
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # @fastify/env
 
 ![CI](https://github.com/fastify/fastify-env/workflows/CI/badge.svg)
@@ -9,15 +8,15 @@ Fastify plugin to check environment variables
 
 ## Install
 
-```bash
+```
 npm i @fastify/env
 ```
 
 ## Usage
 
 ```js
-const fastify = require('fastify')();
-const fastifyEnv = require('@fastify/env');
+const fastify = require('fastify')()
+const fastifyEnv = require('@fastify/env')
 
 const schema = {
   type: 'object',
@@ -28,42 +27,41 @@ const schema = {
       default: 3000
     }
   }
-};
+}
 
 const options = {
   confKey: 'config', // optional, default: 'config'
   schema: schema,
   data: data // optional, default: process.env
-};
+}
 
 fastify
   .register(fastifyEnv, options)
   .ready((err) => {
-    if (err) console.error(err);
+    if (err) console.error(err)
 
-    console.log(fastify.config); // or fastify[options.confKey]
-    console.log(fastify.getEnvs());
+    console.log(fastify.config) // or fastify[options.confKey]
+    console.log(fastify.getEnvs())
     // output: { PORT: 3000 }
-  });
+  })
 ```
 
-You can also use the function `getEnvs()` of the Request from within a handler function:
-
+You can also use the function `getEnvs()` of the Request from within a handler function: 
 ```js
 fastify.get('/', (request, reply) => {
-    console.log(request.getEnvs());
+    console.log(request.getEnvs())
     // output: { PORT: 3000 }
-});
+})
 ```
-
 Note that the `getEnvs` decorators will not be added if they already exist.
 
-This module is a wrapper around [env-schema](https://www.npmjs.com/package/env-schema). To read an `.env` file, you must set `dotenv` in the options:
+This module is a wrapper around [env-schema](https://www.npmjs.com/package/env-schema).
+To read an `.env` file you must set `dotenv` in the options:
 
 ```js
 const options = {
   dotenv: true // will read .env in root folder
-};
+}
 
 // or, pass config options available on dotenv module
 const options = {
@@ -71,74 +69,65 @@ const options = {
     path: `${__dirname}/.env`,
     debug: true
   }
-};
+}
+
 ```
-
-### Using @fastify/env to Configure Other Plugins
-
-The `@fastify/env` plugin loads asynchronously. To use its values in a different plugin before the boot sequence, you need to make sure that:
+### Using @fastify/env to configure other plugins
+The `@fastify/env` plugin loads asynchronously. If you wish to use its values in a different plugin before the boot sequence, you need to make sure that:
 1. `@fastify/env` is registered first.
-2. Await the plugin registration or use `await fastify.ready()`.
+2. Await the plugin registration or await after()
 
 ```js
-await fastify.register(fastifyEnv);
+await fastify.register(fastifyEnv)
 // fastify.config can be used in here
 ```
 
 OR
-
 ```js
-fastify.register(fastifyEnv);
-await fastify.ready();
+fastify.register(fastifyEnv)
+await fastify
 // fastify.config can be used in here
 ```
+**NB** Support for additional properties in the schema is disabled for this plugin, with the `additionalProperties` flag set to `false` internally.
 
-**NB:** Support for additional properties in the schema is disabled for this plugin, with the `additionalProperties` flag set to `false` internally.
+### Typescript
+In order to have typing for the fastify instance, you should either:
 
-### TypeScript
-
-To properly type the Fastify instance with TypeScript, follow one of these approaches:
-
-#### 1. Declaration Merging
-
-Use declaration merging to enhance the `FastifyInstance` type with the properties and keys defined in your options:
+- use the `declaration merging` technique to enhance the `FastifyInstance` type with the property and its keys you have defined in the options:
 
 ```typescript
 declare module 'fastify' {
   interface FastifyInstance {
-    config: { // this should be the same as the confKey in options
+    config: { // this should be same as the confKey in options
       // specify your typing here
-      FOO: string;
+      FOO: string
     };
   }
 }
 
-const fastify = Fastify();
-fastify.register(fastifyEnv);
+const fastify = Fastify()
+fastify.register(fastifyEnv)
 
-fastify.config.FOO; // will be a string
-fastify.config.BAR; // error: Property BAR does not exist on type { FOO: string }
+fastify.config.FOO // will be a string
+fastify.config.BAR // error: Property BAR does not exist on type { FOO: string }
 ```
 
-#### 2. Using `getEnvs()` Generic Function
-
-Use the generic function `getEnvs()` to obtain a typed object:
+- use the generic function `getEnvs()` to get the already typed object:
 
 ```typescript
 type Envs = {
-  FOO: string;
-};
+  FOO: string
+}
 
-const fastify = Fastify();
-await fastify.register(fastifyEnv);
+const fastify = Fastify()
+await fastify.register(fastifyEnv)
 
-const envs = fastify.getEnvs<Envs>(); // envs will be of type Envs
+const envs = fastify.getEnvs<Envs>() // envs will be of type Envs
 
-envs.FOO; // will be a string
-envs.BAR; // error: Property BAR does not exist on type Envs
+envs.FOO // will be a string
+envs.BAR // error: Property BAR does not exist on type Envs
 ```
-
-To keep types synchronized with the schema, consider using [json-schema-to-ts](https://github.com/ThomasAribart/json-schema-to-ts).
+If this is the case it is suggested to use [json-schema-to-ts ](https://github.com/ThomasAribart/json-schema-to-ts) to have the type always synchronized with the actual schema. 
 
 ### Handling `.env` Files in TypeScript Projects
 
@@ -156,4 +145,3 @@ This script will compile your TypeScript code and copy the `.env` file to the `d
 ## Acknowledgements
 
 Kindly sponsored by [Mia Platform](https://www.mia-platform.eu/)
-

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ If this is the case it is suggested to use [json-schema-to-ts ](https://github.c
 
 ### Handling `.env` Files in TypeScript Projects
 
+
 To ensure that the `.env` file is copied to the `dist/` directory after TypeScript compilation, you can add a post-build step to your `package.json` scripts:
 
 ```json
@@ -139,8 +140,10 @@ To ensure that the `.env` file is copied to the `dist/` directory after TypeScri
   "start": "node dist/app.js"
 }
 ```
-
 This script will compile your TypeScript code and copy the `.env` file to the `dist/` directory.
+
+Warning: This step may not be needed for all projects. When you point to a specific path for your .env file, make sure it’s included in the build output and verify that it’s in the correct location. In TypeScript projects, paths like __dirname and import.meta.dirname can differ between development and production. Adjust according to your project’s needs to avoid confusion.
+
 
 ## Acknowledgements
 


### PR DESCRIPTION
Description: This update introduces a new post-build step in the package.json scripts to handle .env files in TypeScript projects. Specifically, the change adds a script that copies the .env file to the dist/ directory after TypeScript compilation.

Details:

Added Script: The build script in package.json now includes cp .env dist/, which copies the .env file to the dist/ directory.
Purpose: This ensures that the .env file is included in the build output and available for runtime use, which is critical for configurations required during application execution.

Related Issue: This change addresses [Issue #171]
(https://github.com/fastify/fastify-env/issues/171), where it was noted that the .env file was missing from the build output.

Checklist:

 Run npm run test and npm run benchmark to ensure the changes do not break existing functionality.
 Tests and/or benchmarks are included (if applicable).
 Documentation has been updated to reflect these changes.
 The commit message and code adhere to the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of Conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md).