### PR TITLE
chore: removed types deprecated

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,11 +20,6 @@ declare namespace fastifyEnv {
     confKey?: string
   }
 
-  /**
-   * @deprecated Use FastifyEnvOptions instead
-   */
-  export type fastifyEnvOpt = FastifyEnvOptions
-
   export const fastifyEnv: FastifyEnv
   export { fastifyEnv as default }
 }


### PR DESCRIPTION
Proposal:

- Drop `fastifyEnvOpt` type alias that was marked as `@deprecated`in favour of `FastifyEnvOptions


Note:

- Release a major version of the plugin after this pull request has been merged
- PR reference:
   - https://github.com/fastify/fastify-swagger-ui/pull/274